### PR TITLE
fix: handle detached HEAD, nothing-to-sync, and unmerged branch deletion

### DIFF
--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -87,6 +87,18 @@ load helpers
   [[ "$output" =~ ^.+\|main\|[0-9a-f]{7}$ ]]
 }
 
+@test "list_worktrees: detached HEAD worktree shows (detached) as branch" {
+  local base="$BATS_TEST_TMPDIR/repos"
+  setup_repo "$base/main"
+  local sha
+  sha="$(git -C "$base/main" rev-parse HEAD)"
+  git -C "$base/main" worktree add --detach "$base/detached" "$sha"
+
+  run zsh -c "source '$WT_ZSH' && cd '$base/main' && _wt_list_worktrees"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "(detached)" ]]
+}
+
 @test "list_worktrees: additional worktree appears in output" {
   local base="$BATS_TEST_TMPDIR/repos"
   setup_repo "$base/main"
@@ -268,6 +280,24 @@ load helpers
   [ ! -d "$base/dirty-force" ]
 }
 
+@test "wt rm: prints warning and keeps unmerged branch instead of force-deleting" {
+  local base="$BATS_TEST_TMPDIR/repos"
+  setup_repo "$base/main"
+  git -C "$base/main" worktree add -q -b unmerged-wt "$base/unmerged-wt"
+  # Add a commit to the worktree branch so git branch -d refuses it
+  echo "unmerged" > "$base/unmerged-wt/unmerged.txt"
+  git -C "$base/unmerged-wt" add .
+  git -C "$base/unmerged-wt" commit -q -m "unmerged commit"
+
+  run zsh -c "source '$WT_ZSH' && cd '$base/main' && _wt_cmd_rm unmerged-wt"
+  [ "$status" -eq 0 ]
+  # Worktree directory is removed ...
+  [ ! -d "$base/unmerged-wt" ]
+  # ... but branch still exists (not force-deleted)
+  run git -C "$base/main" branch --list unmerged-wt
+  [[ "$output" =~ "unmerged-wt" ]]
+}
+
 @test "wt rm: fails with helpful message for non-existent branch" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_repo "$repo"
@@ -405,6 +435,18 @@ load helpers
   [ "$status" -eq 0 ]
   # rsync default: src wins on untracked files; that's expected behaviour —
   # just verify the command completes without error
+}
+
+@test "sync_files: prints nothing-to-sync message when no untracked or env files" {
+  local base="$BATS_TEST_TMPDIR/sync-empty"
+  setup_repo "$base/src"
+  local dst="$base/dst"
+  mkdir -p "$dst"
+  # No untracked files, no env files — only committed content
+
+  run zsh -c "source '$WT_ZSH' && _wt_sync_files '$base/src' '$dst'"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to sync" ]]
 }
 
 @test "sync_files: preserves nested path structure for env files" {

--- a/wt.zsh
+++ b/wt.zsh
@@ -1,6 +1,7 @@
 # wt — git worktree management suite
 # Single-file implementation (required: cd must run in the calling shell)
 # Source this file from .zshrc
+# shellcheck shell=bash
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -105,10 +106,11 @@ _wt_worktree_for_branch() {
 # Returns lines of "path|branch|sha" for all worktrees
 _wt_list_worktrees() {
   git worktree list --porcelain | awk '
-    /^worktree / { path = substr($0, 10) }
-    /^HEAD /     { sha = substr($0, 6, 7) }
-    /^branch /   { b = substr($0, 8); sub("^refs/heads/", "", b) }
-    /^(bare)?$/  {
+    /^worktree /  { path = substr($0, 10) }
+    /^HEAD /      { sha = substr($0, 6, 7) }
+    /^branch /    { b = substr($0, 8); sub("^refs/heads/", "", b) }
+    /^detached$/  { b = "(detached)" }
+    /^(bare)?$/   {
       if (path != "") print path "|" b "|" sha
       path=""; b=""; sha=""
     }
@@ -214,7 +216,9 @@ _wt_sync_files() {
   git -C "$src" ls-files --others --exclude-standard \
     | grep -Ev '^(node_modules|\.git|\.next|dist|out|build|\.turbo|coverage|\.nyc_output)/' \
     > "$tmpfile" || true
+  local files_synced=false
   if [[ -s "$tmpfile" ]]; then
+    files_synced=true
     echo "wt sync: copying untracked files..." >&2
     rsync -a "${excludes[@]}" --files-from="$tmpfile" "$src/" "$dst/"
   fi
@@ -233,7 +237,7 @@ _wt_sync_files() {
   local found_any=false
   while IFS= read -r src_file; do
     found_any=true
-    local rel_path="${src_file#$src/}"
+    local rel_path="${src_file#"$src"/}"
     local dst_file="$dst/$rel_path"
     local dst_dir
     dst_dir="$(dirname "$dst_file")"
@@ -248,7 +252,7 @@ _wt_sync_files() {
     \( "${env_patterns[@]}" \) \
     -type f 2>/dev/null)
 
-  if ! $found_any && ! [[ -s "$tmpfile" ]]; then
+  if ! $found_any && ! $files_synced; then
     echo "wt sync: nothing to sync" >&2
   fi
 }
@@ -572,9 +576,10 @@ _wt_cmd_rm() {
   git worktree prune
 
   if ! $keep_branch; then
-    git branch -d "$branch" 2>/dev/null || \
-      git branch -D "$branch" 2>/dev/null || \
-      echo "wt: could not delete branch '$branch' (may not exist locally)" >&2
+    if ! git branch -d "$branch" 2>/dev/null; then
+      echo "wt: branch '$branch' has unmerged commits and was not deleted" >&2
+      echo "     merge or use --keep-branch to preserve it" >&2
+    fi
   fi
 
   echo "wt: done"


### PR DESCRIPTION
## Summary

Fixes three bugs identified by exploration (#2, #3, #4):

- **#4** `_wt_list_worktrees`: detached HEAD worktrees had an empty branch field causing display/parsing issues. Added awk pattern for the `detached` keyword → shows `(detached)` as branch name.

- **#3** `_wt_sync_files`: "nothing to sync" message never appeared because the tmpfile was already `rm -f`'d before the check at the end. Added a `files_synced` boolean flag captured before deletion.

- **#2** `_wt_cmd_rm`: silent `git branch -D` fallback could force-delete unmerged branches (data loss risk). Replaced with a clear error message that leaves the branch intact and tells the user to merge or use `--keep-branch`.

Also adds `# shellcheck shell=bash` directive (resolves SC2148) and fixes SC2295 pattern quoting in `_wt_sync_files`. Remaining shellcheck warnings (SC2181, SC2329, SC2016, SC2164) are in functions owned by agent-2 and will be addressed in their PR.

Closes #2
Closes #3
Closes #4

## Test plan

- [ ] `bats tests/` passes (50/50 — 3 new tests added)
- [ ] `wt ls` shows `(detached)` for detached HEAD worktrees
- [ ] `wt sync` on a clean worktree prints "nothing to sync"
- [ ] `wt rm` on a worktree with unmerged commits removes directory but keeps branch, prints warning