### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            wt.zsh


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes
- Creates a GitHub Release with auto-generated notes from commit history
- Attaches `wt.zsh` as a release asset so users can download a specific version
- Uses `gh release create --generate-notes` for automatic changelog

## Usage (after merge)

```bash
git tag v0.1.0
git push origin v0.1.0
# → GitHub Release v0.1.0 created with wt.zsh attached
```

## Test plan

- [ ] Merge this PR
- [ ] Push a `v0.1.0` tag
- [ ] Verify Release appears at github.com/knoxio/wt/releases with `wt.zsh` asset